### PR TITLE
uppercase properties for the response object

### DIFF
--- a/DalSoft.RestClient/Extensions/Json.cs
+++ b/DalSoft.RestClient/Extensions/Json.cs
@@ -14,7 +14,7 @@ namespace DalSoft.RestClient.Extensions
             type = type ?? typeof(object);
             try
             {
-                result = ParseCamelcase(json);
+                result = ParsePascalCase(json);
                 return true;
             }
             catch (Exception ex)
@@ -54,18 +54,18 @@ namespace DalSoft.RestClient.Extensions
 
 
         // https://stackoverflow.com/questions/35777561/get-a-dynamic-object-for-jsonconvert-deserializeobject-making-properties-upperca
-        internal static JToken ParseCamelcase(string json)
+        internal static JToken ParsePascalCase(string json)
         {
             using (var textReader = new StringReader(json))
             using (var jsonReader = new JsonTextReader(textReader))
             {
-                return jsonReader.ParseCamelcase();
+                return jsonReader.ParsePascalCase();
             }
         }
 
-        internal static JToken ParseCamelcase(this JsonReader reader)
+        internal static JToken ParsePascalCase(this JsonReader reader)
         {
-            return reader.ParseCamelcase(n =>
+            return reader.ParsePascalCase(n =>
             {
                 char[] a = n.ToCharArray();
                 a[0] = char.ToUpper(a[0]);
@@ -73,7 +73,7 @@ namespace DalSoft.RestClient.Extensions
             });
         }
 
-        internal static JToken ParseCamelcase(this JsonReader reader, Func<string, string> nameMap)
+        internal static JToken ParsePascalCase(this JsonReader reader, Func<string, string> nameMap)
         {
             JToken token;
 

--- a/DalSoft.RestClient/Extensions/Json.cs
+++ b/DalSoft.RestClient/Extensions/Json.cs
@@ -2,6 +2,8 @@
 using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
+using System.IO;
 
 namespace DalSoft.RestClient.Extensions
 {
@@ -12,7 +14,7 @@ namespace DalSoft.RestClient.Extensions
             type = type ?? typeof(object);
             try
             {
-                result = JsonConvert.DeserializeObject(json, type);
+                result = ParseCamelcase(json);
                 return true;
             }
             catch (Exception ex)
@@ -48,6 +50,40 @@ namespace DalSoft.RestClient.Extensions
             }
 
             return result;
+        }
+
+
+        // https://stackoverflow.com/questions/35777561/get-a-dynamic-object-for-jsonconvert-deserializeobject-making-properties-upperca
+        internal static JToken ParseCamelcase(string json)
+        {
+            using (var textReader = new StringReader(json))
+            using (var jsonReader = new JsonTextReader(textReader))
+            {
+                return jsonReader.ParseCamelcase();
+            }
+        }
+
+        internal static JToken ParseCamelcase(this JsonReader reader)
+        {
+            return reader.ParseCamelcase(n =>
+            {
+                char[] a = n.ToCharArray();
+                a[0] = char.ToUpper(a[0]);
+                return new string(a);
+            });
+        }
+
+        internal static JToken ParseCamelcase(this JsonReader reader, Func<string, string> nameMap)
+        {
+            JToken token;
+
+            using (var writer = new RenamingJTokenWriter(nameMap))
+            {
+                writer.WriteToken(reader);
+                token = writer.Token;
+            }
+
+            return token;
         }
     }
 }

--- a/DalSoft.RestClient/Extensions/RenamingJTokenWriter.cs
+++ b/DalSoft.RestClient/Extensions/RenamingJTokenWriter.cs
@@ -1,0 +1,29 @@
+using Newtonsoft.Json.Linq;
+using System;
+using System.Linq;
+
+namespace DalSoft.RestClient.Extensions
+{
+    /// <summary>
+    /// Helper class for renaming json-objects
+    /// </summary>
+    class RenamingJTokenWriter : JTokenWriter
+    {
+        readonly Func<string, string> nameMap;
+
+        public RenamingJTokenWriter(Func<string, string> nameMap)
+            : base()
+        {
+            if (nameMap == null)
+                throw new ArgumentNullException();
+            this.nameMap = nameMap;
+        }
+
+        public override void WritePropertyName(string name)
+        {
+            base.WritePropertyName(nameMap(name));
+        }
+
+        // No need to override WritePropertyName(string name, bool escape) since it calls WritePropertyName(string name)
+    }
+}


### PR DESCRIPTION
What really bothered me was if the response returns lowercase property names, they can only be accessed like that. This pull request will convert all property names to start with an uppercase letter.
This also reflects the [capitalization conventions for C#](https://msdn.microsoft.com/en-us/library/ms229043(v=vs.100).aspx).
