### PR TITLE
Dictionary support for queries

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,29 @@
+# This workflow will build a .NET project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+
+name: .NET
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "none"
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -26,4 +26,4 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test DalSoft.RestClient.Test.Unit/DalSoft.RestClient.Test.Unit.csproj --no-build --verbosity normal

--- a/DalSoft.RestClient.Test.Integration/DynamicRestClientTests.cs
+++ b/DalSoft.RestClient.Test.Integration/DynamicRestClientTests.cs
@@ -157,7 +157,7 @@ namespace DalSoft.RestClient.Test.Integration
             var content = result.ToString();
 
             Assert.That(result.HttpResponseMessage.StatusCode, Is.EqualTo(HttpStatusCode.OK));
-            Assert.That(content, Does.Contain("Terms of Service"));
+            Assert.That(content.Contains("Google News"), Is.True, "Expected content to contain 'Google News'.");
         }
 
         [Test]

--- a/DalSoft.RestClient.Test.Integration/RestClientFactoryTests.cs
+++ b/DalSoft.RestClient.Test.Integration/RestClientFactoryTests.cs
@@ -49,7 +49,7 @@ namespace DalSoft.RestClient.Test.Integration
             var result = await restClient2.Headers(new Headers { { "Accept", "text/html" } } ).news.Get();
             var content = result.ToString();
 
-            Assert.That(content, Does.Contain("Terms of Service"));
+            Assert.That(content.Contains("Google News"), Is.True, "Expected content to contain 'Google News'.");
         }
 
         [Test]

--- a/DalSoft.RestClient.Test.Integration/RestClientTests.cs
+++ b/DalSoft.RestClient.Test.Integration/RestClientTests.cs
@@ -161,7 +161,7 @@ namespace DalSoft.RestClient.Test.Integration
             var content = result.ToString();
 
             Assert.That(result.HttpResponseMessage.StatusCode, Is.EqualTo(HttpStatusCode.OK));
-            Assert.That(content, Does.Contain("Terms of Service"));
+            Assert.That(content.Contains("Google News"), Is.True, "Expected content to contain 'Google News'.");
         }
 
         [Test]

--- a/DalSoft.RestClient.Test.Unit/RestClientTests.cs
+++ b/DalSoft.RestClient.Test.Unit/RestClientTests.cs
@@ -121,9 +121,15 @@ namespace DalSoft.RestClient.Test.Unit
             list.Add(true);
 
             if (callDynamically)
+            {
+                Console.WriteLine("Actual generated URL: " + client.Users.Query(list));
                 await client.Users.Query(list).Get();
+            }
             else
+            {
+                Console.WriteLine("Actual generated URL: " + ((IRestClient)client).Query(list));
                 await ((IRestClient)client).Query(list).Get();
+            }
 
             mockHttpClient.Verify(_ => _.Send
             (

--- a/DalSoft.RestClient.Test.Unit/RestClientTests.cs
+++ b/DalSoft.RestClient.Test.Unit/RestClientTests.cs
@@ -122,12 +122,10 @@ namespace DalSoft.RestClient.Test.Unit
 
             if (callDynamically)
             {
-                Console.WriteLine("Actual generated query: " + client.Users.Query(list));
                 await client.Users.Query(list).Get();
             }
             else
             {
-                Console.WriteLine("Actual generated query: " + ((IRestClient)client).Query(list));
                 await ((IRestClient)client).Query(list).Get();
             }
 

--- a/DalSoft.RestClient.Test.Unit/RestClientTests.cs
+++ b/DalSoft.RestClient.Test.Unit/RestClientTests.cs
@@ -120,9 +120,6 @@ namespace DalSoft.RestClient.Test.Unit
             list.Add(89);
             list.Add(true);
 
-// Access the compiled URI from the RequestMessage
-string fullUrlWithParams = response.HttpResponseMessage.RequestMessage.RequestUri.ToString();
-
             if (callDynamically)
             {
                 Console.WriteLine("Actual generated query: " + client.Users.Query(list));

--- a/DalSoft.RestClient.Test.Unit/RestClientTests.cs
+++ b/DalSoft.RestClient.Test.Unit/RestClientTests.cs
@@ -134,13 +134,19 @@ namespace DalSoft.RestClient.Test.Unit
             mockHttpClient.Verify(_ => _.Send
             (
                 HttpMethod.Get,
-                It.Is<Uri>(__ => __ throw new Exception($"Failed URL: {__}")),
+                It.Is<Uri>(__ => __ FailAndPrint(__)),
                 //It.Is<Uri>(__ => __ == new Uri($"{BaseUri}{(callDynamically ? "/Users" : string.Empty)}?0=string&1=89&2=true")),
                 It.IsAny<IDictionary<string, string>>(),
                 It.IsAny<object>()
             ));
         }
 
+        private bool FailAndPrint(Uri uri)
+        {
+            Console.WriteLine("Final URL was: {uri}");
+            return true;
+        }
+        
         [TestCase(true), TestCase(false)]
         public async Task Query_StringThatRequiresEncoding_EncodesStringCorrectly(bool callDynamically)
         {

--- a/DalSoft.RestClient.Test.Unit/RestClientTests.cs
+++ b/DalSoft.RestClient.Test.Unit/RestClientTests.cs
@@ -76,6 +76,65 @@ namespace DalSoft.RestClient.Test.Unit
 
 
         [TestCase(true), TestCase(false)]
+        public async Task Query_ShouldSerializeDictToQueryString(bool callDynamically)
+        {
+            var mockHttpClient = new Mock<IHttpClientWrapper>();
+
+            mockHttpClient
+                .Setup(_ => _.Send(HttpMethod.Get, It.IsAny<Uri>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<object>()))
+                .Returns(Task.FromResult(new HttpResponseMessage { RequestMessage = new HttpRequestMessage()}));
+
+            dynamic client = new RestClient(mockHttpClient.Object, BaseUri);
+
+            var dict = new Dictionary<string, object>();
+            dict.add("Id", "test");
+            dict.add("another", 1);
+
+            if (callDynamically)
+                await client.Users.Query(dict).Get();
+            else
+                await ((IRestClient)client).Query(dict).Get();
+
+            mockHttpClient.Verify(_ => _.Send
+            (
+                HttpMethod.Get,
+                It.Is<Uri>(__ => __ == new Uri($"{BaseUri}{(callDynamically ? "/Users" : string.Empty)}?Id=test&another=1")),
+                It.IsAny<IDictionary<string, string>>(),
+                It.IsAny<object>()
+            ));
+        }
+
+        [TestCase(true), TestCase(false)]
+        public async Task Query_ShouldSerializeListToQueryString(bool callDynamically)
+        {
+            var mockHttpClient = new Mock<IHttpClientWrapper>();
+
+            mockHttpClient
+                .Setup(_ => _.Send(HttpMethod.Get, It.IsAny<Uri>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<object>()))
+                .Returns(Task.FromResult(new HttpResponseMessage { RequestMessage = new HttpRequestMessage()}));
+
+            dynamic client = new RestClient(mockHttpClient.Object, BaseUri);
+
+            var list = new List<object>();
+            list.add("string");
+            list.add(89);
+            list.add(true);
+
+            if (callDynamically)
+                await client.Users.Query(list).Get();
+            else
+                await ((IRestClient)client).Query(dict).Get();
+
+            mockHttpClient.Verify(_ => _.Send
+            (
+                HttpMethod.Get,
+                It.Is<Uri>(__ => __ == new Uri($"{BaseUri}{(callDynamically ? "/Users" : string.Empty)}?list=string&list=89&list=true")),
+                It.IsAny<IDictionary<string, string>>(),
+                It.IsAny<object>()
+            ));
+        }
+
+        [TestCase(true), TestCase(false)]
         public async Task Query_StringThatRequiresEncoding_EncodesStringCorrectly(bool callDynamically)
         {
             var mockHttpClient = new Mock<IHttpClientWrapper>();

--- a/DalSoft.RestClient.Test.Unit/RestClientTests.cs
+++ b/DalSoft.RestClient.Test.Unit/RestClientTests.cs
@@ -128,7 +128,7 @@ namespace DalSoft.RestClient.Test.Unit
             mockHttpClient.Verify(_ => _.Send
             (
                 HttpMethod.Get,
-                It.Is<Uri>(__ => __ == new Uri($"{BaseUri}{(callDynamically ? "/Users" : string.Empty)}?list=string&list=89&list=true")),
+                It.Is<Uri>(__ => __ == new Uri($"{BaseUri}{(callDynamically ? "/Users" : string.Empty)}?0=string&1=89&2=true")),
                 It.IsAny<IDictionary<string, string>>(),
                 It.IsAny<object>()
             ));

--- a/DalSoft.RestClient.Test.Unit/RestClientTests.cs
+++ b/DalSoft.RestClient.Test.Unit/RestClientTests.cs
@@ -122,12 +122,12 @@ namespace DalSoft.RestClient.Test.Unit
 
             if (callDynamically)
             {
-                Console.WriteLine("Actual generated URL: " + client.Users.Query(list));
+                Console.WriteLine("Actual generated query: " + client.Users.Query(list).Query);
                 await client.Users.Query(list).Get();
             }
             else
             {
-                Console.WriteLine("Actual generated URL: " + ((IRestClient)client).Query(list));
+                Console.WriteLine("Actual generated query: " + ((IRestClient)client).Query(list).Query);
                 await ((IRestClient)client).Query(list).Get();
             }
 

--- a/DalSoft.RestClient.Test.Unit/RestClientTests.cs
+++ b/DalSoft.RestClient.Test.Unit/RestClientTests.cs
@@ -87,8 +87,8 @@ namespace DalSoft.RestClient.Test.Unit
             dynamic client = new RestClient(mockHttpClient.Object, BaseUri);
 
             var dict = new Dictionary<string, object>();
-            dict.add("Id", "test");
-            dict.add("another", 1);
+            dict.Add("Id", "test");
+            dict.Add("another", 1);
 
             if (callDynamically)
                 await client.Users.Query(dict).Get();
@@ -116,14 +116,14 @@ namespace DalSoft.RestClient.Test.Unit
             dynamic client = new RestClient(mockHttpClient.Object, BaseUri);
 
             var list = new List<object>();
-            list.add("string");
-            list.add(89);
-            list.add(true);
+            list.Add("string");
+            list.Add(89);
+            list.Add(true);
 
             if (callDynamically)
                 await client.Users.Query(list).Get();
             else
-                await ((IRestClient)client).Query(dict).Get();
+                await ((IRestClient)client).Query(list).Get();
 
             mockHttpClient.Verify(_ => _.Send
             (

--- a/DalSoft.RestClient.Test.Unit/RestClientTests.cs
+++ b/DalSoft.RestClient.Test.Unit/RestClientTests.cs
@@ -108,11 +108,20 @@ namespace DalSoft.RestClient.Test.Unit
         public async Task Query_ShouldSerializeListToQueryString(bool callDynamically)
         {
             var mockHttpClient = new Mock<IHttpClientWrapper>();
+						Uri actualUri = null;
+						
+            //mockHttpClient
+            //    .Setup(_ => _.Send(HttpMethod.Get, It.IsAny<Uri>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<object>()))
+            //    .Returns(Task.FromResult(new HttpResponseMessage { RequestMessage = new HttpRequestMessage()}));
 
-            mockHttpClient
-                .Setup(_ => _.Send(HttpMethod.Get, It.IsAny<Uri>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<object>()))
-                .Returns(Task.FromResult(new HttpResponseMessage { RequestMessage = new HttpRequestMessage()}));
-
+						mockHttpClient
+    						.Setup(_ => _.Send(HttpMethod.Get, It.IsAny<Uri>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<object>()))
+    						.Returns((HttpMethod method, Uri uri, IDictionary<string, string> headers, object body) => 
+    						{
+        						actualUri = uri; // Intercepts the actual URI right here
+        						return Task.FromResult(new HttpResponseMessage { RequestMessage = new HttpRequestMessage() });
+    						});
+    
             dynamic client = new RestClient(mockHttpClient.Object, BaseUri);
 
             var list = new List<object>();
@@ -134,19 +143,14 @@ namespace DalSoft.RestClient.Test.Unit
             mockHttpClient.Verify(_ => _.Send
             (
                 HttpMethod.Get,
-                It.Is<Uri>(__ => __ FailAndPrint(__)),
+                It.Is<Uri>(__ => __ .ToString().ToLower().Contains("89")),
                 //It.Is<Uri>(__ => __ == new Uri($"{BaseUri}{(callDynamically ? "/Users" : string.Empty)}?0=string&1=89&2=true")),
                 It.IsAny<IDictionary<string, string>>(),
                 It.IsAny<object>()
             ));
+            Assert.Fail($"The actual URL requested was: {actualUri}");
         }
 
-        private bool FailAndPrint(Uri uri)
-        {
-            Console.WriteLine("Final URL was: {uri}");
-            return true;
-        }
-        
         [TestCase(true), TestCase(false)]
         public async Task Query_StringThatRequiresEncoding_EncodesStringCorrectly(bool callDynamically)
         {

--- a/DalSoft.RestClient.Test.Unit/RestClientTests.cs
+++ b/DalSoft.RestClient.Test.Unit/RestClientTests.cs
@@ -134,7 +134,7 @@ namespace DalSoft.RestClient.Test.Unit
             mockHttpClient.Verify(_ => _.Send
             (
                 HttpMethod.Get,
-                It.Is<Uri>(__ => __ .ToString().ToLower().Contains("89")),
+                It.Is<Uri>(__ => __ throw new Exception($"Failed URL: {__}")),
                 //It.Is<Uri>(__ => __ == new Uri($"{BaseUri}{(callDynamically ? "/Users" : string.Empty)}?0=string&1=89&2=true")),
                 It.IsAny<IDictionary<string, string>>(),
                 It.IsAny<object>()

--- a/DalSoft.RestClient.Test.Unit/RestClientTests.cs
+++ b/DalSoft.RestClient.Test.Unit/RestClientTests.cs
@@ -108,20 +108,11 @@ namespace DalSoft.RestClient.Test.Unit
         public async Task Query_ShouldSerializeListToQueryString(bool callDynamically)
         {
             var mockHttpClient = new Mock<IHttpClientWrapper>();
-						Uri actualUri = null;
 						
-            //mockHttpClient
-            //    .Setup(_ => _.Send(HttpMethod.Get, It.IsAny<Uri>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<object>()))
-            //    .Returns(Task.FromResult(new HttpResponseMessage { RequestMessage = new HttpRequestMessage()}));
+            mockHttpClient
+                .Setup(_ => _.Send(HttpMethod.Get, It.IsAny<Uri>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<object>()))
+                .Returns(Task.FromResult(new HttpResponseMessage { RequestMessage = new HttpRequestMessage()}));
 
-						mockHttpClient
-    						.Setup(_ => _.Send(HttpMethod.Get, It.IsAny<Uri>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<object>()))
-    						.Returns((HttpMethod method, Uri uri, IDictionary<string, string> headers, object body) => 
-    						{
-        						actualUri = uri; // Intercepts the actual URI right here
-        						return Task.FromResult(new HttpResponseMessage { RequestMessage = new HttpRequestMessage() });
-    						});
-    
             dynamic client = new RestClient(mockHttpClient.Object, BaseUri);
 
             var list = new List<object>();
@@ -143,12 +134,10 @@ namespace DalSoft.RestClient.Test.Unit
             mockHttpClient.Verify(_ => _.Send
             (
                 HttpMethod.Get,
-                It.Is<Uri>(__ => __ .ToString().ToLower().Contains("89")),
-                //It.Is<Uri>(__ => __ == new Uri($"{BaseUri}{(callDynamically ? "/Users" : string.Empty)}?0=string&1=89&2=true")),
+                It.Is<Uri>(__ => __ == new Uri($"{BaseUri}{(callDynamically ? "/Users" : string.Empty)}?0=string&1=89&2=True")),
                 It.IsAny<IDictionary<string, string>>(),
                 It.IsAny<object>()
             ));
-            Assert.Fail($"The actual URL requested was: {actualUri}");
         }
 
         [TestCase(true), TestCase(false)]

--- a/DalSoft.RestClient.Test.Unit/RestClientTests.cs
+++ b/DalSoft.RestClient.Test.Unit/RestClientTests.cs
@@ -120,6 +120,9 @@ namespace DalSoft.RestClient.Test.Unit
             list.Add(89);
             list.Add(true);
 
+// Access the compiled URI from the RequestMessage
+string fullUrlWithParams = response.HttpResponseMessage.RequestMessage.RequestUri.ToString();
+
             if (callDynamically)
             {
                 Console.WriteLine("Actual generated query: " + client.Users.Query(list));
@@ -135,7 +138,7 @@ namespace DalSoft.RestClient.Test.Unit
             (
                 HttpMethod.Get,
                 It.Is<Uri>(__ => __ .ToString().ToLower().Contains("89")),
-                It.Is<Uri>(__ => __ == new Uri($"{BaseUri}{(callDynamically ? "/Users" : string.Empty)}?0=string&1=89&2=true")),
+                //It.Is<Uri>(__ => __ == new Uri($"{BaseUri}{(callDynamically ? "/Users" : string.Empty)}?0=string&1=89&2=true")),
                 It.IsAny<IDictionary<string, string>>(),
                 It.IsAny<object>()
             ));

--- a/DalSoft.RestClient.Test.Unit/RestClientTests.cs
+++ b/DalSoft.RestClient.Test.Unit/RestClientTests.cs
@@ -900,28 +900,6 @@ namespace DalSoft.RestClient.Test.Unit
         }
 
         [Test]
-        public void Query_NonAnonymousArg_ThrowsArgumentException()
-        {
-            dynamic client = new RestClient(BaseUri, new Config(new UnitTestHandler()));
-            
-            var verbs = new Func<Task<dynamic>>[]
-            {
-                ()=>client.Users.Query(new User { id = 1 }).Get(),
-                ()=>client.Users.Query(new User { id = 1 }).Head(),
-                ()=>client.Users.Query(new User { id = 1 }).Delete(),
-                ()=>client.Users.Query(new User { id = 1 }).Post(),
-                ()=>client.Users.Query(new User { id = 1 }).Put(),
-                ()=>client.Users.Query(new User { id = 1 }).Patch(),
-                ()=>client.Users.Query(new User { id = 1 }).Merge()
-            };
-
-            foreach (var verb in verbs)
-            {
-                Assert.ThrowsAsync<ArgumentException>(async () => await verb());
-            }
-        }
-
-        [Test]
         public void Query_MoreThanOneArg_ThrowsArgumentException()
         {
             dynamic client = new RestClient(BaseUri, new Config(new UnitTestHandler()));

--- a/DalSoft.RestClient.Test.Unit/RestClientTests.cs
+++ b/DalSoft.RestClient.Test.Unit/RestClientTests.cs
@@ -134,7 +134,7 @@ namespace DalSoft.RestClient.Test.Unit
             mockHttpClient.Verify(_ => _.Send
             (
                 HttpMethod.Get,
-                It.Is<Uri>(uri => { Console.WriteLine("Actual URI: " + uri); return true; }),
+                It.Is<Uri>(__ => __ .ToString().ToLower().Contains("89")),
                 It.Is<Uri>(__ => __ == new Uri($"{BaseUri}{(callDynamically ? "/Users" : string.Empty)}?0=string&1=89&2=true")),
                 It.IsAny<IDictionary<string, string>>(),
                 It.IsAny<object>()

--- a/DalSoft.RestClient.Test.Unit/RestClientTests.cs
+++ b/DalSoft.RestClient.Test.Unit/RestClientTests.cs
@@ -122,18 +122,19 @@ namespace DalSoft.RestClient.Test.Unit
 
             if (callDynamically)
             {
-                Console.WriteLine("Actual generated query: " + client.Users.Query(list).Query);
+                Console.WriteLine("Actual generated query: " + client.Users.Query(list));
                 await client.Users.Query(list).Get();
             }
             else
             {
-                Console.WriteLine("Actual generated query: " + ((IRestClient)client).Query(list).Query);
+                Console.WriteLine("Actual generated query: " + ((IRestClient)client).Query(list));
                 await ((IRestClient)client).Query(list).Get();
             }
 
             mockHttpClient.Verify(_ => _.Send
             (
                 HttpMethod.Get,
+                It.Is<Uri>(uri => { Console.WriteLine("Actual URI: " + uri); return true; }),
                 It.Is<Uri>(__ => __ == new Uri($"{BaseUri}{(callDynamically ? "/Users" : string.Empty)}?0=string&1=89&2=true")),
                 It.IsAny<IDictionary<string, string>>(),
                 It.IsAny<object>()

--- a/DalSoft.RestClient/Commands/QueryCommand.cs
+++ b/DalSoft.RestClient/Commands/QueryCommand.cs
@@ -52,7 +52,7 @@ namespace DalSoft.RestClient.Commands
 
         private static string Encode(string data)
         {
-            return string.IsNullOrEmpty(data) ? string.Empty : Uri.EscapeDataString(data).Replace("%20", "+");
+            return string.IsNullOrEmpty(data) ? string.Empty : Uri.EscapeDataString(data);
         }
     }
 }

--- a/DalSoft.RestClient/Commands/QueryCommand.cs
+++ b/DalSoft.RestClient/Commands/QueryCommand.cs
@@ -19,12 +19,12 @@ namespace DalSoft.RestClient.Commands
                 throw new ArgumentException("Please provide a query");
 
             if (args.Length != 1)
-                throw new ArgumentException("Query has one argument");
+                throw new ArgumentException("Query may not have more than one argument");
         }
 
         protected override object Handle(object[] args, MemberAccessWrapper next)
         {
-           var queryString = ToQueryString(args[0].FlattenObjectToKeyValuePairs<string>(includeThisType: Object.IsValueTypeOrPrimitiveOrStringOrGuidOrDateTime));
+            var queryString = ToQueryString(args[0].FlattenToKeyValuePairs<string>(includeThisType: Object.IsValueTypeOrPrimitiveOrStringOrGuidOrDateTime));
 
             return new MemberAccessWrapper
             (

--- a/DalSoft.RestClient/Commands/QueryCommand.cs
+++ b/DalSoft.RestClient/Commands/QueryCommand.cs
@@ -20,9 +20,6 @@ namespace DalSoft.RestClient.Commands
 
             if (args.Length != 1)
                 throw new ArgumentException("Query has one argument");
-
-            if (args[0].GetType().Namespace != null)
-                throw new ArgumentException("Query must be a anonymous type");
         }
 
         protected override object Handle(object[] args, MemberAccessWrapper next)

--- a/DalSoft.RestClient/Commands/QueryCommand.cs
+++ b/DalSoft.RestClient/Commands/QueryCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using DalSoft.RestClient.Extensions;
 using Object = DalSoft.RestClient.Extensions.Object;
@@ -24,7 +25,8 @@ namespace DalSoft.RestClient.Commands
 
         protected override object Handle(object[] args, MemberAccessWrapper next)
         {
-            var queryString = ToQueryString(args[0].FlattenToKeyValuePairs(includeThisType: Object.IsValueTypeOrPrimitiveOrStringOrGuidOrDateTime));
+            var queryString = ToQueryString(args[0].FlattenToKeyValuePairs(includeThisType: Object.IsValueTypeOrPrimitiveOrStringOrGuidOrDateTime)
+                .Select(kvp => new KeyValuePair<string, string>(kvp.Key, kvp.Value?.FormatAsString())));
 
             return new MemberAccessWrapper
             (

--- a/DalSoft.RestClient/Commands/QueryCommand.cs
+++ b/DalSoft.RestClient/Commands/QueryCommand.cs
@@ -24,7 +24,7 @@ namespace DalSoft.RestClient.Commands
 
         protected override object Handle(object[] args, MemberAccessWrapper next)
         {
-            var queryString = ToQueryString(args[0].FlattenToKeyValuePairs<string>(includeThisType: Object.IsValueTypeOrPrimitiveOrStringOrGuidOrDateTime));
+            var queryString = ToQueryString(args[0].FlattenToKeyValuePairs(includeThisType: Object.IsValueTypeOrPrimitiveOrStringOrGuidOrDateTime));
 
             return new MemberAccessWrapper
             (

--- a/DalSoft.RestClient/Commands/ResourceCommand.cs
+++ b/DalSoft.RestClient/Commands/ResourceCommand.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reflection;
 using static DalSoft.RestClient.Extensions.Object;
 
 namespace DalSoft.RestClient.Commands
@@ -35,7 +34,7 @@ namespace DalSoft.RestClient.Commands
             if (args[0] == null)
                 return;
 
-            if (!IsValueTypeOrPrimitiveOrStringOrGuid(args[0].GetType().GetTypeInfo()))
+            if (!IsValueTypeOrPrimitiveOrStringOrGuid(args[0].GetType()))
                 throw new ArgumentException("Resource must be a primitive type, string or a Guid");
         }
     }

--- a/DalSoft.RestClient/Extensions/Object.cs
+++ b/DalSoft.RestClient/Extensions/Object.cs
@@ -18,67 +18,94 @@ namespace DalSoft.RestClient.Extensions
             return PropertyCache.GetOrAdd(type, t => t.GetProperties());
         }
 
-        /// <summary>Returns a List KeyValuePair to pass into FormUrlEncodedContent supports complex objects People[0]First=Darran&amp;People[0]Last=Darran</summary>
-        internal static List<KeyValuePair<string, TValue>> FlattenObjectToKeyValuePairs<TValue>(
-            this object o,
-            Func<TypeInfo, bool> includeThisType,
-            List<KeyValuePair<string, TValue>> nameValueCollection = null, 
-            string prefix = null, int recrusions = 0) 
+        /// <summary>
+        /// Flattens into a list of key/value pairs.
+        /// </summary>
+        public static IEnumerable<KeyValuePair<string, object>> FlattenToKeyValuePairs(
+            this object obj,
+            Func<Type, bool> includeThisType,
+            string prefix = null)
         {
-            const int maxRecrusions = 30;
-            recrusions = prefix == null ? 0 : recrusions + 1;
-            if (recrusions > maxRecrusions) throw new InvalidOperationException("Object supplied to be UrlEncoded is nested too deeply");
+            if (obj == null)
+                yield break;
 
-            nameValueCollection = nameValueCollection ?? new List<KeyValuePair<string, TValue>>();
+            var type = obj.GetType();
 
-            foreach (var property in o.GetType().GetCachedProperties())
+            // 1. Leaf value: primitive / value type / string / Guid / DateTime etc.
+            if (includeThisType(type))
             {
-                var propertyName = prefix == null ? property.Name : $"{prefix}.{property.Name}";
-                var propertyValue = property.GetValue(o);
-
-                if (propertyValue == null) continue;
-
-                if (includeThisType(property.PropertyType.GetTypeInfo()))
-                {
-                    nameValueCollection.Add(new KeyValuePair<string, TValue>(propertyName, (TValue)(typeof(TValue) == typeof(string) ? propertyValue.FormatAsString() : propertyValue)));
-                }
-                else if (propertyValue is IEnumerable)
-                {
-                    var enumerable = ((IEnumerable)propertyValue).Cast<object>().ToArray();
-
-                    for (var i = 0; i < enumerable.Length; i++)
-                    {
-                        if (includeThisType(enumerable[i].GetType().GetTypeInfo())) 
-                        { 
-                            nameValueCollection.Add(new KeyValuePair<string, TValue>(propertyName, (TValue)(typeof(TValue) == typeof(string) ? enumerable[i].FormatAsString() : enumerable[i])));
-                            continue;
-                        }
-
-                        foreach (var propertyItem in enumerable[i].GetType().GetCachedProperties())
-                        {
-                            var propertyItemName = $"{propertyName}[{i}].{propertyItem.Name}";
-                            var propertyItemValue = propertyItem.GetValue(enumerable[i]);
-
-                            if (propertyItemValue == null) continue;
-
-                            if (includeThisType(propertyItem.PropertyType.GetTypeInfo()))
-                            {
-                                nameValueCollection.Add(new KeyValuePair<string, TValue>(propertyItemName, (TValue)(typeof(TValue) == typeof(string) ? propertyItemValue.FormatAsString() : propertyItemValue)));
-                            }
-                            else
-                            {
-                                FlattenObjectToKeyValuePairs<TValue>(propertyItemValue, includeThisType, nameValueCollection, propertyItemName, recrusions);
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    FlattenObjectToKeyValuePairs<TValue>(propertyValue, includeThisType, nameValueCollection, propertyName, recrusions);
-                }
+                yield return new KeyValuePair<string, object>(prefix ?? string.Empty, obj);
+                yield break;
             }
 
-            return nameValueCollection;
+            // 2. Dictionary support (IDictionary)
+            if (obj is IDictionary dict)
+            {
+                foreach (var key in dict.Keys)
+                {
+                    var value = dict[key];
+                    if (value == null)
+                        continue;
+
+                    var keyString = key.ToString();
+                    var childPrefix = string.IsNullOrEmpty(prefix)
+                        ? keyString
+                        : $"{prefix}.{keyString}";
+
+                    foreach (var kvp in FlattenToKeyValuePairs(value, includeThisType, childPrefix))
+                    {
+                        yield return kvp;
+                    }
+                }
+
+                yield break;
+            }
+
+            // 3. Enumerable support (arrays, lists, etc.) but NOT string
+            if (obj is IEnumerable enumerable && !(obj is string))
+            {
+                var index = 0;
+                foreach (var item in enumerable)
+                {
+                    if (item == null)
+                    {
+                        index++;
+                        continue;
+                    }
+
+                    var childPrefix = string.IsNullOrEmpty(prefix)
+                        ? index.ToString()
+                        : $"{prefix}[{index}]";
+
+                    foreach (var kvp in FlattenToKeyValuePairs(item, includeThisType, childPrefix))
+                    {
+                        yield return kvp;
+                    }
+
+                    index++;
+                }
+
+                yield break;
+            }
+
+            // 4. Complex object: reflect properties (anonymous types, POCOs, etc.)
+            var properties = type.GetProperties(BindingFlags.Instance | BindingFlags.Public);
+            foreach (var property in properties)
+            {
+                var value = property.GetValue(obj);
+                if (value == null)
+                    continue;
+
+                var propName = property.Name;
+                var childPrefix = string.IsNullOrEmpty(prefix)
+                    ? propName
+                    : $"{prefix}.{propName}";
+
+                foreach (var kvp in FlattenToKeyValuePairs(value, includeThisType, childPrefix))
+                {
+                    yield return kvp;
+                }
+            }
         }
 
         internal static string FormatAsString(this object o)

--- a/DalSoft.RestClient/Extensions/Object.cs
+++ b/DalSoft.RestClient/Extensions/Object.cs
@@ -82,7 +82,7 @@ namespace DalSoft.RestClient.Extensions
                     // Leaf values (primitives, strings, Guid, DateTime, etc) keep the same key repeated for each item,
                     // whereas complex items are indexed so their properties can be flattened separately.
                     var childPrefix = includeThisType(item.GetType())
-                        ? prefix
+                        ? (prefix ?? index.ToString())
                         : string.IsNullOrEmpty(prefix)
                             ? index.ToString()
                             : $"{prefix}[{index}]";

--- a/DalSoft.RestClient/Extensions/Object.cs
+++ b/DalSoft.RestClient/Extensions/Object.cs
@@ -24,8 +24,14 @@ namespace DalSoft.RestClient.Extensions
         public static IEnumerable<KeyValuePair<string, object>> FlattenToKeyValuePairs(
             this object obj,
             Func<Type, bool> includeThisType,
-            string prefix = null)
+            string prefix = null,
+            int recursions = 0)
         {
+            const int maxRecursions = 30;
+            recursions = prefix == null ? 0 : recursions + 1;
+            if (recursions > maxRecursions)
+                throw new InvalidOperationException("Object supplied to be UrlEncoded is nested too deeply");
+
             if (obj == null)
                 yield break;
 
@@ -52,7 +58,7 @@ namespace DalSoft.RestClient.Extensions
                         ? keyString
                         : $"{prefix}.{keyString}";
 
-                    foreach (var kvp in FlattenToKeyValuePairs(value, includeThisType, childPrefix))
+                    foreach (var kvp in FlattenToKeyValuePairs(value, includeThisType, childPrefix, recursions))
                     {
                         yield return kvp;
                     }
@@ -73,11 +79,15 @@ namespace DalSoft.RestClient.Extensions
                         continue;
                     }
 
-                    var childPrefix = string.IsNullOrEmpty(prefix)
-                        ? index.ToString()
-                        : $"{prefix}[{index}]";
+                    // Leaf values (primitives, strings, Guid, DateTime, etc) keep the same key repeated for each item,
+                    // whereas complex items are indexed so their properties can be flattened separately.
+                    var childPrefix = includeThisType(item.GetType())
+                        ? prefix
+                        : string.IsNullOrEmpty(prefix)
+                            ? index.ToString()
+                            : $"{prefix}[{index}]";
 
-                    foreach (var kvp in FlattenToKeyValuePairs(item, includeThisType, childPrefix))
+                    foreach (var kvp in FlattenToKeyValuePairs(item, includeThisType, childPrefix, recursions))
                     {
                         yield return kvp;
                     }
@@ -101,7 +111,15 @@ namespace DalSoft.RestClient.Extensions
                     ? propName
                     : $"{prefix}.{propName}";
 
-                foreach (var kvp in FlattenToKeyValuePairs(value, includeThisType, childPrefix))
+                // Check the declared property type first (e.g. a property declared as Stream but holding a
+                // FileStream instance) so leaf types aren't reflected into by their concrete runtime type.
+                if (includeThisType(property.PropertyType))
+                {
+                    yield return new KeyValuePair<string, object>(childPrefix, value);
+                    continue;
+                }
+
+                foreach (var kvp in FlattenToKeyValuePairs(value, includeThisType, childPrefix, recursions))
                 {
                     yield return kvp;
                 }
@@ -116,19 +134,19 @@ namespace DalSoft.RestClient.Extensions
             return o.ToString();
         }
 
-        internal static bool IsValueTypeOrPrimitiveOrStringOrGuid(TypeInfo type)
+        internal static bool IsValueTypeOrPrimitiveOrStringOrGuid(Type type)
         {
-            return type.IsValueType || type.IsPrimitive || type.AsType() == typeof(string) || type.AsType() == typeof(Guid);
+            return type.IsValueType || type.IsPrimitive || type == typeof(string) || type == typeof(Guid);
         }
 
-        internal static bool IsValueTypeOrPrimitiveOrStringOrGuidOrDateTime(TypeInfo type)
+        internal static bool IsValueTypeOrPrimitiveOrStringOrGuidOrDateTime(Type type)
         {
-            return IsValueTypeOrPrimitiveOrStringOrGuid(type) || type.AsType() == typeof(DateTime);
+            return IsValueTypeOrPrimitiveOrStringOrGuid(type) || type == typeof(DateTime);
         }
 
-        internal static bool IsValueTypeOrPrimitiveOrStringOrGuidOrDateTimeOrByteArrayOrStream(TypeInfo type)
+        internal static bool IsValueTypeOrPrimitiveOrStringOrGuidOrDateTimeOrByteArrayOrStream(Type type)
         {
-            return IsValueTypeOrPrimitiveOrStringOrGuidOrDateTime(type) || type.AsType() == typeof(byte[]) || type.AsType() == typeof(Stream);
+            return IsValueTypeOrPrimitiveOrStringOrGuidOrDateTime(type) || type == typeof(byte[]) || type == typeof(Stream);
         }
     }
 }

--- a/DalSoft.RestClient/Handlers/FormUrlEncodedHandler.cs
+++ b/DalSoft.RestClient/Handlers/FormUrlEncodedHandler.cs
@@ -14,7 +14,7 @@ namespace DalSoft.RestClient.Handlers
                 var content = request.GetContent();
                 request.Content = content == null ? null : new FormUrlEncodedContent
                 (
-                    content.FlattenObjectToKeyValuePairs<string>(includeThisType:Object.IsValueTypeOrPrimitiveOrStringOrGuidOrDateTime)
+                    content.FlattenToKeyValuePairs<string>(includeThisType:Object.IsValueTypeOrPrimitiveOrStringOrGuidOrDateTime)
                 );
             }
 

--- a/DalSoft.RestClient/Handlers/FormUrlEncodedHandler.cs
+++ b/DalSoft.RestClient/Handlers/FormUrlEncodedHandler.cs
@@ -14,7 +14,7 @@ namespace DalSoft.RestClient.Handlers
                 var content = request.GetContent();
                 request.Content = content == null ? null : new FormUrlEncodedContent
                 (
-                    content.FlattenToKeyValuePairs<string>(includeThisType:Object.IsValueTypeOrPrimitiveOrStringOrGuidOrDateTime)
+                    content.FlattenToKeyValuePairs(includeThisType:Object.IsValueTypeOrPrimitiveOrStringOrGuidOrDateTime)
                 );
             }
 

--- a/DalSoft.RestClient/Handlers/FormUrlEncodedHandler.cs
+++ b/DalSoft.RestClient/Handlers/FormUrlEncodedHandler.cs
@@ -1,4 +1,6 @@
-﻿using System.Net.Http;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using DalSoft.RestClient.Extensions;
@@ -15,6 +17,7 @@ namespace DalSoft.RestClient.Handlers
                 request.Content = content == null ? null : new FormUrlEncodedContent
                 (
                     content.FlattenToKeyValuePairs(includeThisType:Object.IsValueTypeOrPrimitiveOrStringOrGuidOrDateTime)
+                        .Select(kvp => new KeyValuePair<string, string>(kvp.Key, kvp.Value?.FormatAsString()))
                 );
             }
 

--- a/DalSoft.RestClient/Handlers/MultipartFormDataHandler.cs
+++ b/DalSoft.RestClient/Handlers/MultipartFormDataHandler.cs
@@ -36,7 +36,7 @@ namespace DalSoft.RestClient.Handlers
             var boundry = contentType.Length > 1 ? contentType.SingleOrDefault(_=>_.Contains("boundary="))?.Replace("boundary=", string.Empty).Replace("\"", string.Empty) : null;
             var multipartFormDataContent = contentType.Any(_ => _.Contains("boundary=")) ? new MultipartFormDataContent(boundry) : new MultipartFormDataContent();
 
-            var formData = content.FlattenObjectToKeyValuePairs<object>(includeThisType:Object.IsValueTypeOrPrimitiveOrStringOrGuidOrDateTimeOrByteArrayOrStream);
+            var formData = content.FlattenToKeyValuePairs<object>(includeThisType:Object.IsValueTypeOrPrimitiveOrStringOrGuidOrDateTimeOrByteArrayOrStream);
 
             foreach (var pairs in formData.GroupBy(_ => _.Key.Split(".".ToCharArray()).Length))
             {

--- a/DalSoft.RestClient/Handlers/MultipartFormDataHandler.cs
+++ b/DalSoft.RestClient/Handlers/MultipartFormDataHandler.cs
@@ -36,7 +36,7 @@ namespace DalSoft.RestClient.Handlers
             var boundry = contentType.Length > 1 ? contentType.SingleOrDefault(_=>_.Contains("boundary="))?.Replace("boundary=", string.Empty).Replace("\"", string.Empty) : null;
             var multipartFormDataContent = contentType.Any(_ => _.Contains("boundary=")) ? new MultipartFormDataContent(boundry) : new MultipartFormDataContent();
 
-            var formData = content.FlattenToKeyValuePairs<object>(includeThisType:Object.IsValueTypeOrPrimitiveOrStringOrGuidOrDateTimeOrByteArrayOrStream);
+            var formData = content.FlattenToKeyValuePairs(includeThisType:Object.IsValueTypeOrPrimitiveOrStringOrGuidOrDateTimeOrByteArrayOrStream);
 
             foreach (var pairs in formData.GroupBy(_ => _.Key.Split(".".ToCharArray()).Length))
             {


### PR DESCRIPTION
Add support for using Dictionaries (and other first-class/non-anonymous objects) to define query parameters. 

Closes #74 - Query should support Dictionary

(I didn't find any guidelines on contributions. Hoping this PR will be favorably received, as I've been desperately in need of this functionality)
